### PR TITLE
chore: add `docker` to `dependabot` config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,3 +62,10 @@ updates:
     reviewers:
       - abdfnx
       - david-tomson
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - abdfnx


### PR DESCRIPTION
I have notice that some of the dockerfiles are slightly out of date. This PR updates the dependabot configuration, to keep them updated.