### PR TITLE
chore: create `docker` entry for every directory containing dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,35 @@ updates:
       - david-tomson
 
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: "/assets"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - abdfnx
+
+  - package-ecosystem: "docker"
+    directory: "/core"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - abdfnx
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - abdfnx
+
+  - package-ecosystem: "docker"
+    directory: "/dockerfiles"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - abdfnx
+
+  - package-ecosystem: "docker"
+    directory: "/.gitpod"
     schedule:
       interval: "daily"
     reviewers:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,7 +54,7 @@ updates:
       interval: "daily"
     reviewers:
       - abdfnx
-  
+
   - package-ecosystem: "nuget"
     directory: "/packages/botnet"
     schedule:


### PR DESCRIPTION
_Continuation_ of #331. The directories containing docker images where identified with:
```shell
find . -type f \( -name "*.dockerfile" -or -name "Dockerfile" \) -printf "%h\n" | sort -u
```
It gave 5 directories:
```
./assets
./core
./docker
./dockerfiles
./.gitpod
```